### PR TITLE
Improve @nb_extract macro

### DIFF
--- a/src/notebooks/extracters.jl
+++ b/src/notebooks/extracters.jl
@@ -133,10 +133,10 @@ strip_types(x::Symbol) = x
 # This function is used to be able to strip types from the extracted arguments to forward the function call to the gensymed one
 # We want to do something like `fun(a::Something) = MODULE.#xxx#fun(a)`
 function strip_types(x::Expr)::Symbol
-	if Meta.isexpr(x, :(::))
-		return x.args[1] # In case of expr of type x::Something, just return x
+	if Meta.isexpr(x, [:(::), :kw])
+		return strip_types(x.args[1]) # We recursively call strip_types till we reach the symbol or we error
 	else
-		error("This function should only receive either symbols or Expr of the type `x::Something`. Instead `$x` was given as input")
+		error("This function should only receive either symbols or Expr of the type `x::Something`, `x=something` or `x::Something=something`. Instead `$x` was given as input")
 	end
 end
 

--- a/src/notebooks/extracters.jl
+++ b/src/notebooks/extracters.jl
@@ -126,6 +126,20 @@ function nb_extracter(nb::Pluto.Notebook; given=[], outputs=[])
 	)
 end
 
+# ╔═╡ ba256080-73fb-4de4-be72-101318c82029
+strip_types(x::Symbol) = x
+
+# ╔═╡ feadac3a-859c-4915-bfc6-8fa607d6b606
+# This function is used to be able to strip types from the extracted arguments to forward the function call to the gensymed one
+# We want to do something like `fun(a::Something) = MODULE.#xxx#fun(a)`
+function strip_types(x::Expr)::Symbol
+	if Meta.isexpr(x, :(::))
+		return x.args[1] # In case of expr of type x::Something, just return x
+	else
+		error("This function should only receive either symbols or Expr of the type `x::Something`. Instead `$x` was given as input")
+	end
+end
+
 # ╔═╡ c2f701da-aaa7-4af5-bada-5acb05465b3f
 """
     @nb_extract(nb, template)
@@ -225,23 +239,33 @@ macro nb_extract(nb, template)
 			"""))
 	end
 
+	# We gensym the name of the function to be evaluated so it's not easibly accessible directly, in order to make the macro also in let blocks without polluting the global scope
+	gensym_name = gensym(d[:name])
+	# We already create the expression that will be evaluated to map the gensymed function evaluated in the module to the non-gensymed name. This is also useful to trigger Pluto reactivity.
+	expr = let dict = d # Adapted from https://fluxml.ai/MacroTools.jl/dev/utilities/
+		rtype = get(dict, :rtype, :Any)
+		:(function $(dict[:name])($(dict[:args]...);
+		                          $(dict[:kwargs]...))::$rtype where {$(dict[:whereparams]...)}
+		  $(__module__).$(gensym_name)($(strip_types.(dict[:args])...);
+		                          $(strip_types.(dict[:kwargs])...))
+		end)
+	end
+	# We assign the gensym_name to the function name in the dict
+	d[:name] = gensym_name
 	# `nb_extracter_body` needs to know about the real notebook
 	# so the following can only be done at runtime.
 	# => Just prepare the expressions to be evaluated when the macro is executed.
 	return quote
-		local extracted_block = nb_extracter_body(
-			$(esc(nb));
-			given=$given,
-			outputs=$outputs
-		)
-		prepend!($d[:body].args, extracted_block.args)
-
-		if false
-			# equivalent to f(a, b, c) = nothing
-			global $(esc(template.args[begin])) = nothing
+		let
+			extracted_block = nb_extracter_body(
+				$(esc(nb));
+				given=$given,
+				outputs=$outputs
+			)
+			prepend!($d[:body].args, extracted_block.args)
+			$__module__.eval(MacroTools.combinedef($d))
 		end
-
-		$__module__.eval(MacroTools.combinedef($d))
+		$(esc(expr))
 	end
 end
 
@@ -298,7 +322,7 @@ deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[Downloads]]
-deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[ExproniconLite]]
@@ -519,6 +543,8 @@ uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
 # ╠═efa1e893-34b0-4a14-a0e2-600a365eb717
 # ╠═c71b4e52-5d6a-4a82-b465-b755217198e6
 # ╠═ea0ba472-50a3-4ab6-a221-0b710b361fca
+# ╠═ba256080-73fb-4de4-be72-101318c82029
+# ╠═feadac3a-859c-4915-bfc6-8fa607d6b606
 # ╠═c2f701da-aaa7-4af5-bada-5acb05465b3f
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -91,6 +91,25 @@ fun_a_out_nt_b_c(2)
 # ╔═╡ aba92ba2-cd8d-4f87-ad81-892dceed3aa6
 PlutoTest.@test fun_a_out_nt_b_c(2) == (; b = 4, c = 8)
 
+# ╔═╡ 140e69f8-d458-4086-ba1b-e8dbb45b5fb4
+md"""
+## Keyword argument
+"""
+
+# ╔═╡ 66929e56-fb7f-49fe-a0ce-b4a58b558b37
+@nb_extract(
+	nb,
+	function fun_6(; a=2)
+		return c
+	end
+)
+
+# ╔═╡ 7e987ccc-5a5b-44bf-a1bf-33564d8d24b4
+PlutoTest.@test fun_6() == 8
+
+# ╔═╡ 28d6de40-6267-49c0-9d61-cdc06c66e413
+PlutoTest.@test fun_6(; a = 3) == 12
+
 # ╔═╡ 8be6bb27-98c6-4e86-b0b8-7f66693395b6
 md"""
 # Scopes
@@ -153,6 +172,10 @@ PlutoTest.@test_throws MethodError fun_5(2.0)
 # ╠═abfcb9bd-8c20-47a9-9f1c-12e75426d6df
 # ╠═8adbfdd7-a8bb-48a0-bbfa-8a66d80d45da
 # ╠═aba92ba2-cd8d-4f87-ad81-892dceed3aa6
+# ╠═140e69f8-d458-4086-ba1b-e8dbb45b5fb4
+# ╠═66929e56-fb7f-49fe-a0ce-b4a58b558b37
+# ╠═7e987ccc-5a5b-44bf-a1bf-33564d8d24b4
+# ╠═28d6de40-6267-49c0-9d61-cdc06c66e413
 # ╠═8be6bb27-98c6-4e86-b0b8-7f66693395b6
 # ╠═02e44c02-d427-4646-afdc-b52f1e5a9595
 # ╠═34e19103-389b-4dec-bb75-bb6b46a18a18

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -91,6 +91,28 @@ fun_a_out_nt_b_c(2)
 # ╔═╡ aba92ba2-cd8d-4f87-ad81-892dceed3aa6
 PlutoTest.@test fun_a_out_nt_b_c(2) == (; b = 4, c = 8)
 
+# ╔═╡ 8be6bb27-98c6-4e86-b0b8-7f66693395b6
+md"""
+# Scopes
+"""
+
+# ╔═╡ 02e44c02-d427-4646-afdc-b52f1e5a9595
+res_inner = let
+	@nb_extract(
+		nb,
+		function inner_fun(a)
+			return c
+		end
+	)
+	inner_fun(3)
+end
+
+# ╔═╡ 34e19103-389b-4dec-bb75-bb6b46a18a18
+PlutoTest.@test res_inner == 12
+
+# ╔═╡ 3d7cf541-1806-4340-bfdd-2b310a998df3
+PlutoTest.@test @isdefined(inner_fun) === false
+
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
 # ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
@@ -112,3 +134,7 @@ PlutoTest.@test fun_a_out_nt_b_c(2) == (; b = 4, c = 8)
 # ╠═abfcb9bd-8c20-47a9-9f1c-12e75426d6df
 # ╠═8adbfdd7-a8bb-48a0-bbfa-8a66d80d45da
 # ╠═aba92ba2-cd8d-4f87-ad81-892dceed3aa6
+# ╠═8be6bb27-98c6-4e86-b0b8-7f66693395b6
+# ╠═02e44c02-d427-4646-afdc-b52f1e5a9595
+# ╠═34e19103-389b-4dec-bb75-bb6b46a18a18
+# ╠═3d7cf541-1806-4340-bfdd-2b310a998df3

--- a/test/notebooks/extract_from_source_basic.jl
+++ b/test/notebooks/extract_from_source_basic.jl
@@ -113,6 +113,25 @@ PlutoTest.@test res_inner == 12
 # ╔═╡ 3d7cf541-1806-4340-bfdd-2b310a998df3
 PlutoTest.@test @isdefined(inner_fun) === false
 
+# ╔═╡ 20726353-e75e-4da5-94f6-2247e9e51347
+md"""
+# Types
+"""
+
+# ╔═╡ 484fb80e-2722-42b9-bb39-6f2cade9b076
+@nb_extract(
+	nb,
+	function fun_5(a::Int)
+		return c
+	end
+)
+
+# ╔═╡ 88a74364-04b6-4083-a584-eafcdea3e73c
+PlutoTest.@test fun_5(2) == 8
+
+# ╔═╡ f4410aeb-b742-4732-9789-640ec466637a
+PlutoTest.@test_throws MethodError fun_5(2.0)
+
 # ╔═╡ Cell order:
 # ╠═64f6372a-eff1-11ec-2395-31d68eda5f3a
 # ╠═0758f6c1-f7e0-4f9e-911a-c5d21f4b0d50
@@ -138,3 +157,7 @@ PlutoTest.@test @isdefined(inner_fun) === false
 # ╠═02e44c02-d427-4646-afdc-b52f1e5a9595
 # ╠═34e19103-389b-4dec-bb75-bb6b46a18a18
 # ╠═3d7cf541-1806-4340-bfdd-2b310a998df3
+# ╠═20726353-e75e-4da5-94f6-2247e9e51347
+# ╠═484fb80e-2722-42b9-bb39-6f2cade9b076
+# ╠═88a74364-04b6-4083-a584-eafcdea3e73c
+# ╠═f4410aeb-b742-4732-9789-640ec466637a


### PR DESCRIPTION
Hi @ederag, thinking back at the discussion on zulip and how `Base.eval` is always executed in the toplevel, I tried modifying the macro to have a more graceful behavior on that regard.

Now the function itself is `evald` inside the `__module__` with a gensym'd name so that it's still at top level but you are not really polluting the module with sensible names.
The macro itself then just performs a forward to the gensym'd function call like so
```
fun(a) = MODULE.#xxx#fun(a)
```
This way you get the reactivity of Pluto without the need of a `if false` block and you also only bring into the current scope the escaped function name (so it's global only within a begin/end block but not within a `let` block).

I also added the `strip_types` function in order to correctly forward function signatures with typed arguments

Here is a small gif of the behavior:
![c72c3a02-b5c7-4690-9025-18372baef752](https://user-images.githubusercontent.com/12846528/177289587-02a54342-1777-4172-b571-770fc0c14dea.gif)
