### PR TITLE
Use parse_custom (adapted from Pluto)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtractors"
 uuid = "25cc9095-8c7a-4c84-8905-c5de52e7766c"
 authors = ["ederag <edera@gmx.fr> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/test/notebooks/extract_from_source_comments.jl
+++ b/test/notebooks/extract_from_source_comments.jl
@@ -42,34 +42,29 @@ md"""
 # ╔═╡ 214a48ea-1769-45c8-b113-bb17a1a766b7
 md"## Just one variable"
 
-# ╔═╡ 2dff3de8-3643-4e30-8c18-5dbc54c123fd
-VERSION
+# ╔═╡ 3c1f9330-feba-48a5-b6b7-fc6c9f336929
+@nb_extract(
+	source_path,
+	function fun1()
+		return a
+	end
+)
 
-# ╔═╡ b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-if VERSION > v"1.12"
-	PlutoTest.@test_broken load_updated_topology(source_path)
-else
-	utp = load_updated_topology(source_path)
-	@nb_extract(
-		source_path,
-		function fun1()
-			return a
-		end
-	)
-	PlutoTest.@test fun1() == 1
+# ╔═╡ a9437ca3-a038-42c8-9802-d3da71114ae5
+PlutoTest.@test fun1() == 1
 
-	@nb_extract(
+# ╔═╡ 50cd274c-1313-41fb-a4dc-bf2d2d8ae917
+@nb_extract(
 		source_path,
 		function fun2()
 			return b
 		end
 	)
-	# b definition is commented out, so
-	PlutoTest.@test_throws UndefVarError(:b) fun2() == 2
-end
+	
 
-# ╔═╡ 2a62a946-1ca4-486a-a0b3-bbf9b251c373
-
+# ╔═╡ a32303e6-b674-49ba-8a1a-3a3d2f5e520c
+# b definition is commented out, so
+PlutoTest.@test_throws UndefVarError(:b) fun2() == 2
 
 # ╔═╡ 343b1d66-2801-4c31-81f9-1c252bb4d337
 md"""
@@ -80,7 +75,7 @@ md"""
 # ╠═╡ skip_as_script = true
 #=╠═╡
 load_updated_topology(source_path,
-	get_code_expr = c -> (@debug(c.code); Meta.parse(c.code))
+	get_code_expr = c -> (@debug(c.code); PlutoExtractors.parse_custom(c.code))
 )
   ╠═╡ =#
 
@@ -95,8 +90,9 @@ load_updated_topology(source_path,
 # ╠═35bab28c-477c-43dd-b339-13cfdbf2f33e
 # ╟─89dd6ff4-2495-4bd1-96ef-8962f8041cf3
 # ╟─214a48ea-1769-45c8-b113-bb17a1a766b7
-# ╠═2dff3de8-3643-4e30-8c18-5dbc54c123fd
-# ╠═b9e09fd4-f34a-4c72-b979-09bb1b1b57e7
-# ╠═2a62a946-1ca4-486a-a0b3-bbf9b251c373
+# ╠═3c1f9330-feba-48a5-b6b7-fc6c9f336929
+# ╠═a9437ca3-a038-42c8-9802-d3da71114ae5
+# ╠═50cd274c-1313-41fb-a4dc-bf2d2d8ae917
+# ╠═a32303e6-b674-49ba-8a1a-3a3d2f5e520c
 # ╠═343b1d66-2801-4c31-81f9-1c252bb4d337
 # ╠═3570c682-0461-4908-b908-f0bc2cb4a1b4


### PR DESCRIPTION
Fixes #27.
Pluto has been ignoring trailing newlines and comments since 2020,
https://github.com/fonsp/Pluto.jl/blame/97d5382a657df126e6205d5bd585d9ec49645e9b/src/analysis/Parse.jl#L36-L43
and so was not affected.

Can't use `Pluto.parse_custom` directly (its arguments are a notebook and a cell),
hence adapted the relevant code to `PlutoExtractors`.

Only the parse_custom definition,
https://github.com/ederag/PlutoExtractors.jl/blob/89238b3b06845bdf5e1e9e4f988ad065f6a91c09/src/notebooks/extractors.jl#L372-L395

and `Meta.parse` => `parse_custom` are real changes.
The rest is Pluto shuffling things around.